### PR TITLE
Force Qt5 Matplotlib backend and declare PyQt5 dependency

### DIFF
--- a/music_volume_analyser.py
+++ b/music_volume_analyser.py
@@ -5,6 +5,8 @@ import librosa
 import numpy as np
 import librosa.display
 import matplotlib.pyplot as plt
+import matplotlib
+matplotlib.use("Qt5Agg")
 
 folder_path = r"H:\samuel\Raven\raven sounds"
 sound_rms_dict = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "volume-analyzer"
+version = "0.1.0"
+description = "Audio preprocessing utilities that turn MP3 recordings into servo motion maps."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { file = "LICENSE" }
+authors = [
+    { name = "Anat Wax" }
+]
+dependencies = [
+    "librosa>=0.10",
+    "numpy>=1.23",
+    "matplotlib>=3.7",
+    "PyQt5>=5.15"
+]
+
+[project.urls]
+Homepage = "https://github.com/Anatw/volume-analyzer"
+Repository = "https://github.com/Anatw/volume-analyzer"
+
+[tool.setuptools]
+py-modules = ["music_volume_analyser"]


### PR DESCRIPTION
Interactive plots rely on a GUI backend, but Matplotlib defaults to the headless Agg renderer unless a client library is explicitly provided. Adding matplotlib.use("Qt5Agg") ensures the analyzer always requests a GUI backend, and declaring PyQt5 as a dependency guarantees the required Qt client is installed whenever the project is set up.